### PR TITLE
Avoid overlaying container node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,5 @@ services:
       - .env
     volumes:
       - .:/app
+      - /app/node_modules
     command: npm start


### PR DESCRIPTION
## Summary
- keep image-installed dependencies by mounting anonymous volume for node_modules

## Testing
- `npm test`
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68be137f7a00832c81556ce9a449bc80